### PR TITLE
fixed warnings and hyperref link color

### DIFF
--- a/skript/skript.tex
+++ b/skript/skript.tex
@@ -7,6 +7,8 @@
 %
 \documentclass[a4paper,12pt]{book}
 \usepackage[ngerman]{babel}
+\usepackage[T1]{fontenc}
+\usepackage{csquotes}
 \usepackage{times}
 \usepackage{geometry}
 \geometry{papersize={210mm,297mm},total={160mm,240mm},top=31mm,bindingoffset=15mm}
@@ -29,10 +31,12 @@
 \usepackage{algorithmic}
 \usepackage{makeidx}
 \usepackage{paralist}
-\usepackage{hyperref}
+\usepackage[colorlinks=true]{hyperref}
 \usepackage[backend=bibtex]{biblatex}
 \addbibresource{references.bib}
 \makeindex
+\setlength{\headheight}{15pt}
+\newcommand\myatop[2]{\genfrac{}{}{0pt}{}{#1}{#2}}
 \begin{document}
 \pagestyle{fancy}
 \lhead{Automaten und Sprachen}
@@ -58,7 +62,6 @@ Hochschule f"ur Technik, Rapperswil, 2011-2015
 \end{center}
 \end{titlepage}
 \hypersetup{
-    colorlinks=true,
     linktoc=all,
     linkcolor=blue
 }


### PR DESCRIPTION
- for fontenc see:  https://www.cs.cmu.edu/~nbeckman/problem.html -> Some Font Shapre Were Unavailable
- for csquotes see: https://tex.stackexchange.com/questions/229638/package-biblatex-warning-babel-polyglossia-detected-but-csquotes-missing
- headheigth warning fix: http://nw360.blogspot.ch/2006/11/latex-headheight-is-too-small.html
- added myatop command for atop warning -> usage \myatop{top}{bottom}
- fixed hyperref colorlinks, must be set in usepackage to have an effect