### PR TITLE
Fixing typos and warnings during PDF creation

### DIFF
--- a/skript/grundlagen.tex
+++ b/skript/grundlagen.tex
@@ -103,7 +103,7 @@ in disjunktiver Normalform wird bei dieser Art von Umwandlung zu
 \begin{equation}
 (x_1\vee x_2\vee\dots\vee x_{n-1}\vee x_n)
 \wedge
-(x_1\vee x_2\vee\dots\vee x_{n-1}\vee y_n)
+(y_1\vee y_2\vee\dots\vee y_{n-1}\vee y_n)
 \wedge
 \dots 
 =\bigwedge (z_1\vee z_2\vee\dots \vee z_{n-1}\vee z_n),

--- a/skript/komplexitaet.tex
+++ b/skript/komplexitaet.tex
@@ -526,7 +526,7 @@ Die Sprache \textsl{3SAT} ist
 \]
 Wie \textsl{SAT} ist \textsl{3SAT} in NP.
 
-\subsection{Existenz von Cliquen: $k$-\textsl{CLIQUE}}
+\subsection{Existenz von Cliquen: \texorpdfstring{$k$}{k}-\textsl{CLIQUE}}
 \begin{figure}
 \begin{center}
 %\includegraphics[width=0.6\hsize]{images/comp-1}
@@ -576,7 +576,7 @@ weniger Aufwand als die Gr"osse des Graphen brauchen, die
 Komplexit"at dieses Algorithmus ist also $O(n)$, das
 Cliquen-Problem ist in NP.
 
-\subsection{F"arbeproblem: $k$-\textsl{VERTEX-COLORING}}
+\subsection{F"arbeproblem: \texorpdfstring{$k$}{k}-\textsl{VERTEX-COLORING}}
 \index{F\"arbeproblem}
 \begin{figure}
 \begin{center}
@@ -1007,7 +1007,7 @@ f"ur die Zellen $c_{ij}$ die Formel
 \[
 \varphi_{c_{ij}}=
 \biggl(\bigvee_{s\in C} x_{ijs}\biggr)\wedge
-\bigwedge_{s,t\in C\atop s\ne t} (\overline{x_{ijs}}\vee\overline{x_{ijt}}).
+\bigwedge_{\myatop{s,t\in C}{s\ne t}} (\overline{x_{ijs}}\vee\overline{x_{ijt}}).
 \]
 Dies muss f"ur jede Indexkombination gelten, also
 \[
@@ -1018,7 +1018,7 @@ Dies muss f"ur jede Indexkombination gelten, also
 =
 \bigwedge_{1\le i,j\le n^k}\biggl(
 \biggl(\bigvee_{s\in C} x_{ijs}\biggr)\wedge
-\bigwedge_{s,t\in C\atop s\ne t} (\overline{x_{ijs}}\vee\overline{x_{ijt}})
+\bigwedge_{\myatop{s,t\in C}{s\ne t}} (\overline{x_{ijs}}\vee\overline{x_{ijt}})
 \biggr).
 \]
 Da unsere Redukton polynomiell sein soll, m"ussen wir auch bestimmen,

--- a/skript/realworldparser.tex
+++ b/skript/realworldparser.tex
@@ -70,7 +70,7 @@ weil Die Aufforderung ``Schaue nach, ob die obersten $n$ Elemente auf dem Stack
 auf die rechte Seite einer Regel passen'', ist f"ur bei einem Stack nicht
 durchf"uhrbar. Man kann immer nur das oberste Element einsehen.
 
-\subsection{$LR(0)$-Elemente}
+\subsection{\texorpdfstring{$LR(0)$}{LR(0)}-Elemente}
 \index{LR(0)-Element@$LR(0)$-Element}
 Ein Stackautomat kann sich nur dann an den den Stackinhalt unterhalb des obersten
 Stackelementes erinnern, wenn er diese Information in Zust"anden codieren kann.
@@ -119,7 +119,7 @@ am Ende des Wortes, kann die Reduktion agewendet werden.
 Man nennt die so erweiterten
 Produktionsregeln die {\em $LR(0)$-Elemente}.
 
-\subsection{"Ubergangsfunktion des $LR(0)$-Parsers}
+\subsection{"Ubergangsfunktion des \texorpdfstring{$LR(0)$}{LR(0)}-Parsers}
 Wenn eine Reduktionsregel angewendet werden kann, werden so viele Elemente
 aus dem Stack entfernt, wie die rechte Seite der Regel Zeichen hat. Das
 neue oberste Zeichen auf dem Stack ist der letzte Zustand des Automaten
@@ -132,13 +132,13 @@ Hilfe eines Stackautomaten durchf"uhrbar sind. Die einfachste ist nat"urlich
 die Shift-Ope\-ration. Da diese jedoch abh"angig ist vom aktuellen Element zuoberst
 auf dem Stack, braucht es daf"ur zwei Schritte:
 \[
-\boxed{0}\xrightarrow{0,{\tiny \boxed{0}\rightarrow\boxed{0}}}\cdot
-\xrightarrow{\varepsilon,\varepsilon\rightarrow{\tiny \boxed{0}}}\boxed{0}
+\boxed{0}\xrightarrow{0,\scalebox{0.7}{\boxed{0}$\rightarrow$\boxed{0}}}\cdot
+\xrightarrow{\varepsilon,\varepsilon\rightarrow\scalebox{0.7}{\boxed{0}}}\boxed{0}
 \]
 oder
 \[
-\boxed{0}\xrightarrow{1,{\tiny \boxed{0}\rightarrow\boxed{0}}}\cdot
-\xrightarrow{\varepsilon,\varepsilon\rightarrow{\tiny \boxed{01}}}\boxed{01},
+\boxed{0}\xrightarrow{1,\scalebox{0.7}{\boxed{0}$\rightarrow$\boxed{0}}}\cdot
+\xrightarrow{\varepsilon,\varepsilon\rightarrow\scalebox{0.7}{\boxed{01}}}\boxed{01},
 \]
 in beiden F"allen wird ein neuer Zwischenzustand ben"otigt, symbolisiert mit dem Zeichen
 `$\cdot$'.
@@ -149,49 +149,49 @@ n"achste Zustand $\boxed{0w}$. Dies kann man mit folgenden "Uberg"angen
 realisieren:
 \[
 \boxed{01}
-\xrightarrow{\varepsilon,{\tiny\boxed{01}}\to\varepsilon}
+\xrightarrow{\varepsilon,\scalebox{0.7}{\boxed{01}}\to\varepsilon}
 \cdot
-\xrightarrow{\varepsilon,{\tiny\boxed{0}}\to\varepsilon}
+\xrightarrow{\varepsilon,\scalebox{0.7}{\boxed{0}}\to\varepsilon}
 \cdot
-\xrightarrow{\varepsilon,{\tiny\boxed{0}}\to\tiny{\boxed{0}}}
+\xrightarrow{\varepsilon,\scalebox{0.7}{\boxed{0}}\to\scalebox{0.7}{\boxed{0}}}
 \cdot
-\xrightarrow{\varepsilon,{\varepsilon\to\tiny{\boxed{0w}}}}
+\xrightarrow{\varepsilon,\varepsilon\to\scalebox{0.7}{\boxed{0w}}}
 \boxed{0w}
 \]
 Analog kann die Reduktion mit der Regel 1 durchgef"uhrt werden:
 \[
 \boxed{0w1}
-\xrightarrow{\varepsilon,{\tiny\boxed{0w1}}\to\varepsilon}
+\xrightarrow{\varepsilon,\scalebox{0.7}{\boxed{0w1}}\to\varepsilon}
 \cdot
-\xrightarrow{\varepsilon,{\tiny\boxed{0w}}\to\varepsilon}
+\xrightarrow{\varepsilon,\scalebox{0.7}{\boxed{0w}}\to\varepsilon}
 \cdot
-\xrightarrow{\varepsilon,{\tiny\boxed{0}}\to\varepsilon}
+\xrightarrow{\varepsilon,\scalebox{0.7}{\boxed{0}}\to\varepsilon}
 \cdot
-\xrightarrow{\varepsilon,{\tiny\boxed{0}}\to\tiny{\boxed{0}}}
+\xrightarrow{\varepsilon,\scalebox{0.7}{\boxed{0}}\to\scalebox{0.7}{\boxed{0}}}
 \cdot
-\xrightarrow{\varepsilon,{\varepsilon\to\tiny{\boxed{0w}}}}
+\xrightarrow{\varepsilon,\varepsilon\to\scalebox{0.7}{\boxed{0w}}}
 \boxed{0w}
 \]
 Wir k"onnen diese "Uberg"ange etwas einfacher schreiben, wenn wir in der
 Beschriftung der Pfeile erlauben, mehrere Operationen zusammenzufassen.
 Die Shift-Ope\-rationen werden dann zu
 \begin{gather*}
-\boxed{0}\xrightarrow{0,{\tiny \boxed{0}\rightarrow\boxed{0}\,\boxed{0}}}\boxed{0}
+\boxed{0}\xrightarrow{0,\scalebox{0.7}{\boxed{0}$\rightarrow$\boxed{0}\,\boxed{0}}}\boxed{0}
 \\
-\boxed{0}\xrightarrow{1,{\tiny \boxed{0}\rightarrow\boxed{0}\,\boxed{01}}}\boxed{01},
+\boxed{0}\xrightarrow{1,\scalebox{0.7}{\boxed{0}$\rightarrow$\boxed{0}\,\boxed{01}}}\boxed{01}
 \end{gather*}
 die Reduktionsoperationen zu
 \begin{gather*}
 \boxed{01}
-\xrightarrow{\varepsilon,{\tiny\boxed{0}\boxed{01}}\to\varepsilon}
+\xrightarrow{\varepsilon,\scalebox{0.7}{\boxed{0}\,\boxed{01}}\to\varepsilon}
 \cdot
-\xrightarrow{\varepsilon,{\tiny\boxed{0}}\to\tiny{\boxed{0}\,\boxed{0w}}}
+\xrightarrow{\varepsilon,\scalebox{0.7}{\boxed{0}}\to\scalebox{0.7}{\boxed{0}\,\boxed{0w}}}
 \boxed{0w}
 \\
 \boxed{0w1}
-\xrightarrow{\varepsilon,{\tiny\boxed{0}\,\boxed{0w}\,\boxed{0w1}}\to\varepsilon}
+\xrightarrow{\varepsilon,\scalebox{0.7}{\boxed{0}\,\boxed{0w}\,\boxed{0w1}}\to\varepsilon}
 \cdot
-\xrightarrow{\varepsilon,{\tiny\boxed{0}}\to\tiny{\boxed{0}\,\boxed{0w}}}
+\xrightarrow{\varepsilon,\scalebox{0.7}{\boxed{0}}\to\scalebox{0.7}{\boxed{0}\,\boxed{0w}}}
 \boxed{0w}
 \end{gather*}
 In diesem einfachen Bespiel gibt es nur eine M"oglichkeit f"ur den zweiten

--- a/skript/regulaer.tex
+++ b/skript/regulaer.tex
@@ -1052,7 +1052,7 @@ Schritte erreichbar werden.
 E(q)=\{q\} \cup \delta(q,\varepsilon) \cup \delta(\delta(q,\varepsilon),\varepsilon)\cup\dots
 \]
 
-\subsection{``K"onnte''-Automat\label{Thompson-NEA}}
+\subsection{''K"onnte''-Automat\label{Thompson-NEA}}
 Ein NEA hat bei jedem "Ubergang eventuell mehrere Zielst"ande zur Auswahl.
 Eine Implementation muss im Prinzip alle diese M"oglichkeiten 
 durchprobieren.
@@ -1121,7 +1121,7 @@ mit Backtracking. Da er sie in den public domain freigab, hat sie sich
 rasch verbreitet und bildete die Basis Regex-Bibliotheken in Perl, PCRE,
 Python und vielen anderen.
 
-\subsection{Transformation NEA $\rightarrow$ DEA\label{regulaer:nea-dea}}
+\subsection{Transformation NEA \texorpdfstring{$\rightarrow$}{->} DEA\label{regulaer:nea-dea}}
 NEAs f"uhren trotz der betr"achtlichen Erweiterung durch den
 Nichtdeterminismus nicht zu einer gr"osseren Klasse von akzeptierbaren
 Sprachen. Dazu gen"ugt es zu zeigen, dass sich jeder NEA in einen DEA

--- a/skript/skript.tex
+++ b/skript/skript.tex
@@ -7,6 +7,8 @@
 %
 \documentclass[a4paper,12pt]{book}
 \usepackage[ngerman]{babel}
+\usepackage[T1]{fontenc}
+\usepackage{csquotes}
 \usepackage{times}
 \usepackage{geometry}
 \geometry{papersize={210mm,297mm},total={160mm,240mm},top=31mm,bindingoffset=15mm}
@@ -29,10 +31,12 @@
 \usepackage{algorithmic}
 \usepackage{makeidx}
 \usepackage{paralist}
-\usepackage{hyperref}
+\usepackage[colorlinks=true]{hyperref}
 \usepackage[backend=bibtex]{biblatex}
 \addbibresource{references.bib}
 \makeindex
+\setlength{\headheight}{15pt}
+\newcommand\myatop[2]{\genfrac{}{}{0pt}{}{#1}{#2}}
 \begin{document}
 \pagestyle{fancy}
 \lhead{Automaten und Sprachen}
@@ -58,7 +62,6 @@ Hochschule f"ur Technik, Rapperswil, 2011-2015
 \end{center}
 \end{titlepage}
 \hypersetup{
-    colorlinks=true,
     linktoc=all,
     linkcolor=blue
 }

--- a/skript/sudoku.tex
+++ b/skript/sudoku.tex
@@ -90,7 +90,7 @@ Unterfeld davon verschieden ist:
 \varphi_
 {\text{Unterfeldbedingung $(i,j)$}}
 =
-\bigwedge_{{\text{$(k,l)$ im Unterfeld $(i,j)$}}\atop{i\ne k\wedge j\ne l}}(z_{ij}\ne z_{kl}).
+\bigwedge_{\myatop{\text{$(k,l)$ im Unterfeld $(i,j)$}}{i\ne k\wedge j\ne l}}(z_{ij}\ne z_{kl}).
 \]
 \end{compactenum}
 F"ur jedes Feld $(i,j)$ gibt es also drei Bedingungen:


### PR DESCRIPTION
See commit history for details.

- Links are now colored and looking as intended
- PDF bookmarks corrected
- Equation typo (page 6) fixed